### PR TITLE
Fix dashboard trend display overflow

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -141,15 +141,26 @@
     }
 
     /* Bound chart areas to prevent layout expansion */
-    .chart-container {
+    .chart-container,
+    .chart-doughnut-container {
         position: relative;
+        width: 100%;
+        max-width: 100%;
+        overflow: hidden;
+    }
+    .chart-container {
         height: 320px;
         max-height: 60vh;
     }
     .chart-doughnut-container {
-        position: relative;
         height: 240px;
         max-height: 50vh;
+    }
+    .chart-container canvas,
+    .chart-doughnut-container canvas {
+        display: block;
+        width: 100% !important;
+        height: 100% !important;
     }
 </style>
 @endpush
@@ -358,7 +369,9 @@ document.addEventListener('DOMContentLoaded', function () {
         scales: {
           y: { beginAtZero: true, ticks: { precision:0 } }
         },
-        plugins: { legend: { display: false } }
+        plugins: { legend: { display: false } },
+        animation: false,
+        resizeDelay: 200
       }
     });
   }
@@ -380,7 +393,9 @@ document.addEventListener('DOMContentLoaded', function () {
         plugins: { legend: { display: false } },
         cutout: '60%',
         responsive: true,
-        maintainAspectRatio: false
+        maintainAspectRatio: false,
+        animation: false,
+        resizeDelay: 200
       }
     });
   }


### PR DESCRIPTION
Constrain dashboard trend and doughnut charts to prevent layout expansion.

---
<a href="https://cursor.com/background-agent?bcId=bc-18f58391-2de0-48d4-95d6-014963e99b01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18f58391-2de0-48d4-95d6-014963e99b01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

