### PR TITLE
Change dashboard background to blue

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -83,10 +83,7 @@
     }
 
     .stats-card {
-        background-image: url('{{ asset('images/Union.png') }}');
-        background-size: cover;
-        background-position: center;
-        background-repeat: no-repeat;
+        background-color: #3b82f6;
         color: white;
         padding: 5rem 2rem;
         text-align: center;


### PR DESCRIPTION
Change dashboard statistics section background to blue.

---
<a href="https://cursor.com/background-agent?bcId=bc-a87960b7-5c2b-48eb-85ac-c71820a3a695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a87960b7-5c2b-48eb-85ac-c71820a3a695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

